### PR TITLE
Did you miss the 'published' condition?

### DIFF
--- a/lib/processor_post.js
+++ b/lib/processor_post.js
@@ -145,11 +145,13 @@ module.exports = function(ctx) {
 
       return Post.insert(data);
     }).then(function(doc) {
-      return Promise.all([
-        doc.setCategories(categories),
-        doc.setTags(tags),
-        scanAssetDir(doc)
-      ]);
+      if(doc.published){
+        return Promise.all([
+          doc.setCategories(categories),
+          doc.setTags(tags),
+          scanAssetDir(doc)
+        ]);
+      }
     });
   }
 


### PR DESCRIPTION
when I was using this library, I found strange situation..
I have only one folder in '_posts' directory, and many folders in '_drafts' directory.
like
```
- _drafts
    - jpa
    - spring
    - etc
- _posts
    - test
```

after 'hexo clean && hexo generate'
It created following categories.
```
- ..
- _drafts
- jpa
- spring
- etc
- test
```

so I checked this source, I think this library isn't use 'published' condition.

check please. Thank you