### PR TITLE
check if _draft option turned on

### DIFF
--- a/lib/processor_post.js
+++ b/lib/processor_post.js
@@ -46,6 +46,10 @@ module.exports = ctx => {
       return;
     }
 
+    if(!ctx.env.args.draft && !file.params.published){
+      return;
+    }
+
     return Promise.all([
       file.stat(),
       file.read()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-directory-category",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Automatically add category to Hexo article according to the article file directory.",
   "main": "index",
   "scripts": {


### PR DESCRIPTION
I think this option seems to be needed.  
It create categories with under `_draft` folder only when I give `--draft` option.  

Before now It always created categories with under `_draft` directory,   
I think it's not many people expected.  

If I did something wrong, give me feedback.  
Thank you.  